### PR TITLE
Mutiny 0.19.2 and BOM isolation

### DIFF
--- a/.build/render-documentation.sh
+++ b/.build/render-documentation.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-mvn -s .build/maven-ci-settings.xml -f vertx-mutiny-clients/pom.xml pre-site
+mvn -s .build/maven-ci-settings.xml -f vertx-mutiny-clients/pom.xml -B pre-site
 cp -R vertx-mutiny-clients/target/site/apidocs docs/
 
 PROJECT_VERSION=$(cat .github/project.yml | yq eval '.release.current-version' -)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,10 @@ jobs:
         with:
           java-version: ${{matrix.java}}
 
+      - name: validate format
+        run: mvn -s .build/maven-ci-settings.xml -f pom.xml -B -pl '!vertx-mutiny-clients-bom' formatter:validate
       - name: build with maven
-        run: mvn -s .build/maven-ci-settings.xml -f pom.xml -B formatter:validate verify
+        run: mvn -s .build/maven-ci-settings.xml -f pom.xml -B verify
 
   quality:
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           git config --global user.name "SmallRye CI"
           git config --global user.email "smallrye@googlegroups.com"
           git checkout -b release
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
+          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -DautoVersionSubmodules -s maven-settings.xml
           git checkout ${{github.base_ref}}
           git rebase release
           mvn -B release:perform -Prelease -s maven-settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <packaging>pom</packaging>
 
     <name>SmallRye Reactive Utilities</name>
+    <url>https://smallrye.io/smallrye-mutiny-vertx-bindings</url>
 
     <inceptionYear>2019</inceptionYear>
     <organization>
@@ -44,7 +45,7 @@
 
     <properties>
         <vertx.version>4.1.1</vertx.version>
-        <mutiny.version>0.18.1</mutiny.version>
+        <mutiny.version>0.19.2</mutiny.version>
         <jackson.version>2.12.3</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 

--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -71,7 +71,6 @@
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.nexus.staging.plugin>1.6.8</version.nexus.staging.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
-        <version.versions.plugin>2.8.1</version.versions.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -435,14 +434,6 @@
                     <localCheckout>true</localCheckout>
                     <remoteTagging>false</remoteTagging>
                     <arguments>-DskipTests ${release.arguments}</arguments>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${version.versions.plugin}</version>
-                <configuration>
-                    <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
             </plugin>
         </plugins>

--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -1,17 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.smallrye.reactive</groupId>
-        <artifactId>smallrye-mutiny-vertx-bindings-projects</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
-    </parent>
-
+    <groupId>io.smallrye.reactive</groupId>
     <artifactId>vertx-mutiny-clients-bom</artifactId>
-    <name>SmallRye Mutiny - Client APIs BOM</name>
+    <version>2.9.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
+
+    <name>SmallRye Mutiny - Vert.x Client APIs BOM</name>
+    <description>Bill of materials for the Mutiny Vert.x client modules.</description>
+    <url>https://smallrye.io/smallrye-mutiny-vertx-bindings</url>
+
+    <inceptionYear>2019</inceptionYear>
+    <organization>
+        <name>SmallRye</name>
+        <url>https://wwww.smallrye.io</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <id>cescoffier</id>
+            <name>Clement Escoffier</name>
+            <email>clement[AT]apache[DOT]org</email>
+            <url>https://github.com/cescoffier</url>
+        </developer>
+        <developer>
+            <id>jponge</id>
+            <name>Julien Ponge</name>
+            <email>julien[AT]ponge[DOT]org</email>
+            <url>https://github.com/jponge</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git@github.com:smallrye/smallrye-mutiny-vertx-bindings.git</connection>
+        <developerConnection>scm:git:git@github.com:smallrye/smallrye-mutiny-vertx-bindings.git</developerConnection>
+        <url>https://github.com/smallrye/smallrye-mutiny-vertx-bindings</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>oss.sonatype</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>oss.sonatype</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <properties>
+        <version.gpg.plugin>3.0.1</version.gpg.plugin>
+        <version.nexus.staging.plugin>1.6.8</version.nexus.staging.plugin>
+        <version.release.plugin>2.5.3</version.release.plugin>
+        <version.versions.plugin>2.8.1</version.versions.plugin>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -333,5 +397,88 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${version.gpg.plugin}</version>
+                    <configuration>
+                        <gpgArguments>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                        </gpgArguments>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${version.nexus.staging.plugin}</version>
+                    <configuration>
+                        <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${version.release.plugin}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <preparationGoals>verify</preparationGoals>
+                    <pushChanges>false</pushChanges>
+                    <localCheckout>true</localCheckout>
+                    <remoteTagging>false</remoteTagging>
+                    <arguments>-DskipTests ${release.arguments}</arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${version.versions.plugin}</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <serverId>oss.sonatype</serverId>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
- Bump to Mutiny 0.19.2
- Isolate the BOM
- Also update the release version in submodules
