### PR TITLE
2.14.2 release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 2.14.1
+  current-version: 2.14.2
   next-version: 2.15.0-SNAPSHOT


### PR DESCRIPTION
If possible, I would like to have the `Automatic-Module-Name`s right now, so I'm proposing this release. Not sure if leaving `next-version` at `2.15.0-SNAPSHOT` breaks anything? 