### PR TITLE
Add missing vertx-mutiny-generator to BOM

### DIFF
--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -391,6 +391,11 @@
                 <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-zookeeper</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>vertx-mutiny-generator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Ref: https://github.com/quarkusio/quarkus/pull/20873

Dependency vertx-mutiny-generator is required in order to generate mutiny stubs from a Quarkus/Vertx core implementation.
