### PR TITLE
Release 2.19.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 2.18.1
-  next-version: 2.19.0-SNAPSHOT
+  current-version: 2.19.0
+  next-version: 2.20.0-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
         <vertx.version>4.2.5</vertx.version>
-        <mutiny.version>1.3.1</mutiny.version>
+        <mutiny.version>1.4.0</mutiny.version>
         <jackson.version>2.13.2</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
         <vertx.version>4.2.5</vertx.version>
         <mutiny.version>1.3.1</mutiny.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 
         <rxjava3.version>3.1.3</rxjava3.version>

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -179,7 +179,7 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.17.1</version>
+                        <version>2.17.2</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
- Upgrade to Mutiny 1.4.0
- Trigger the next release
