### PR TITLE
Preparation for Vert.x 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.2.5</vertx.version>
+        <vertx.version>4.3.0-SNAPSHOT</vertx.version>
         <mutiny.version>1.4.0</mutiny.version>
         <jackson.version>2.13.2</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
@@ -249,6 +249,13 @@
         <repository>
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>sonatype-s01-snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -19,6 +19,7 @@
         <module>vertx-mutiny-mail-client</module>
         <module>vertx-mutiny-bridge-common</module>
         <module>vertx-mutiny-web-common</module>
+        <module>vertx-mutiny-uri-template</module>
         <module>vertx-mutiny-web</module>
         <module>vertx-mutiny-web-client</module>
         <module>vertx-mutiny-mongo-client</module>

--- a/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>smallrye-mutiny-vertx-web</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -8,12 +10,13 @@
         <version>2.20.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>smallrye-mutiny-vertx-web</artifactId>
-    <name>SmallRye Mutiny - Vert.x Web</name>
+    <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
+
+    <name>SmallRye Mutiny - Vert.x URI Template</name>
 
     <properties>
         <gen-source-groupId>io.vertx</gen-source-groupId>
-        <gen-source-artifactId>vertx-web</gen-source-artifactId>
+        <gen-source-artifactId>vertx-uri-template</gen-source-artifactId>
         <gen.output>${project.build.directory}/sources/java</gen.output>
     </properties>
 
@@ -25,7 +28,7 @@
             <version>${vertx.version}</version>
         </dependency>
 
-        <!-- Vert.x Mutiny Core -->
+        <!-- Vert.x mutiny Core -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-mutiny-vertx-core</artifactId>
@@ -33,65 +36,13 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-bridge-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-jwt</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-htdigest</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-webauthn</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-auth-otp</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -123,16 +74,18 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.web</Automatic-Module-Name>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.redis.client</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>

--- a/vertx-mutiny-clients/vertx-mutiny-uri-template/src/test/java/io/vertx/mutiny/uritemplate/UriTemplateTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-uri-template/src/test/java/io/vertx/mutiny/uritemplate/UriTemplateTest.java
@@ -1,0 +1,18 @@
+package io.vertx.mutiny.uritemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class UriTemplateTest {
+
+    /**
+     * Example taken from https://en.wikipedia.org/wiki/URI_Template.
+     */
+    @Test
+    public void test() {
+        String string = UriTemplate.of("http://example.com/people/{firstName}-{lastName}/SSN")
+                .expandToString(Variables.variables().set("firstName", "foo").set("lastName", "bar"));
+        assertThat(string).isEqualTo("http://example.com/people/foo-bar/SSN");
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
@@ -42,7 +42,11 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
- Add the URI template module
- Add the missing dependencies on the URI template module
- Declare the new snapshot repository used by Vert.x
