### PR TITLE
Remove unused imports in the generated classes

### DIFF
--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/ImportDeclarationCodeWriter.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/ImportDeclarationCodeWriter.java
@@ -27,8 +27,6 @@ public class ImportDeclarationCodeWriter implements CodeWriter {
         writer.println("import " + Multi.class.getName() + ";");
         writer.println("import " + Uni.class.getName() + ";");
         writer.println("import " + Consumer.class.getName() + ";");
-        writer.println("import " + Subscriber.class.getName() + ";");
-        writer.println("import " + Publisher.class.getName() + ";");
         writer.println("import " + TypeArg.class.getName() + ";");
         writer.println("import " + Fluent.class.getName() + ";");
         writer.println("import " + CheckReturnValue.class.getName() + ";");


### PR DESCRIPTION
The Publisher and Subscriber classes do not need to be imported as it use the fully qualified class name in the generated code.

Fix #492. 