### PR TITLE
Remove non-existing vertx-mutiny-clients jar from the BOM

### DIFF
--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -78,11 +78,6 @@
         <dependencies>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>vertx-mutiny-clients</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-mutiny-vertx-runtime</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This is probably an oversight but just in case, to make it a valid constraint `<type>pom</type>` would have to be added. But given that dependencies on this POM are unlikely, it could simply be removed.