### PR TITLE
Update the Web Client to 4.3.2.1 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
                             <!-- Do not check for Vert.x, only focus on the client API -->
                             <checkDependencies>false</checkDependencies>
                             <generateSiteReport>false</generateSiteReport>
-                            <oldVersion>2.16.0</oldVersion>
+                            <oldVersion>2.23.0</oldVersion>
                             <newVersion>${project.version}</newVersion>
 
                             <analysisConfiguration>

--- a/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
@@ -22,7 +22,8 @@
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
             <artifactId>${gen-source-artifactId}</artifactId>
-            <version>${vertx.version}</version>
+            <!-- This is because of the close method that changed its signature in 4.3.3 -->
+            <version>${vertx.version}.1</version>
         </dependency>
 
         <!-- Vert.x Mutiny Core -->


### PR DESCRIPTION
which revert the close method signature change.