### PR TITLE
2.x - update vertx 4.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To generate the compatibility report, you need:
 Generate the report with:
 
 ```bash
-mvn verify -DskipTests revapi:report@revapi-check  -Prevapi -DskipTests -Dmaven.javadoc.skip=true -pl \!vertx-mutiny-clients-bom
+mvn verify -DskipTests revapi:report@revapi-check  -Prevapi -DskipTests -Dmaven.javadoc.skip=true -pl \!vertx-mutiny-clients-bom -pl \!vertx-mutiny-clients/vertx-mutiny-sql-client
 jbang CompatibilityReport.java && asciidoctor target/compatibility-report.adoc
 ``` 
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.3.2</vertx.version>
+        <vertx.version>4.3.3</vertx.version>
         <mutiny.version>1.7.0</mutiny.version>
         <jackson.version>2.13.3</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
                             <!-- Do not check for Vert.x, only focus on the client API -->
                             <checkDependencies>false</checkDependencies>
                             <generateSiteReport>false</generateSiteReport>
-                            <oldVersion>2.23.0</oldVersion>
+                            <oldVersion>2.25.0</oldVersion>
                             <newVersion>${project.version}</newVersion>
 
                             <analysisConfiguration>

--- a/vertx-mutiny-clients/vertx-mutiny-amqp-client/src/test/java/io/vertx/mutiny/amqp/AMQPClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-amqp-client/src/test/java/io/vertx/mutiny/amqp/AMQPClientTest.java
@@ -19,7 +19,10 @@ import io.vertx.mutiny.core.Vertx;
 public class AMQPClientTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>("vromero/activemq-artemis:latest")
+    public GenericContainer<?> container = new GenericContainer<>("quay.io/artemiscloud/activemq-artemis-broker:1.0.6")
+            .withEnv("AMQ_USER", "admin")
+            .withEnv("AMQ_PASSWORD", "admin")
+            .withEnv("AMQ_EXTRA_ARGS", "--nio")
             .withExposedPorts(5672);
 
     private Vertx vertx;

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <gen-source-groupId>io.vertx</gen-source-groupId>
         <gen-source-artifactId>vertx-core</gen-source-artifactId>
-        <gen-source-version>4.3.3</gen-source-version>
+        <gen-source-version>${vertx.version}</gen-source-version>
         <gen.output>${project.build.directory}/sources/java</gen.output>
     </properties>
 

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <gen-source-groupId>io.vertx</gen-source-groupId>
         <gen-source-artifactId>vertx-core</gen-source-artifactId>
-        <gen-source-version>${vertx.version}</gen-source-version>
+        <gen-source-version>4.3.3</gen-source-version>
         <gen.output>${project.build.directory}/sources/java</gen.output>
     </properties>
 

--- a/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
@@ -147,6 +147,20 @@
                 <maven.test.skip>true</maven.test.skip>
             </properties>
         </profile>
+
+        <profile>
+            <id>arm</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <!-- No DB2 image for ARM - https://hub.docker.com/r/ibmcom/db2/tags -->
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+
+        </profile>
     </profiles>
 
 </project>

--- a/vertx-mutiny-clients/vertx-mutiny-mail-client/src/test/java/io/vertx/mutiny/mail/MailClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mail-client/src/test/java/io/vertx/mutiny/mail/MailClientTest.java
@@ -8,7 +8,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.ext.mail.MailConfig;
@@ -19,9 +18,8 @@ import io.vertx.mutiny.ext.mail.MailClient;
 public class MailClientTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>("digiplant/fake-smtp:latest")
-            .withExposedPorts(25)
-            .withFileSystemBind("target", "/tmp/fakemail", BindMode.READ_WRITE);
+    public GenericContainer<?> container = new GenericContainer<>("mailhog/mailhog:latest")
+            .withExposedPorts(1025);
 
     private Vertx vertx;
 
@@ -39,8 +37,8 @@ public class MailClientTest {
     @Test
     public void testMutinyAPI() {
         MailClient client = MailClient.createShared(vertx, new MailConfig()
-                .setPort(container.getMappedPort(25))
-                .setHostname(container.getContainerIpAddress()));
+                .setPort(container.getMappedPort(1025))
+                .setHostname(container.getHost()));
         assertThat(client, is(notNullValue()));
         client.sendMail(new MailMessage().setText("hello mutiny")
                 .setSubject("test email")
@@ -53,8 +51,8 @@ public class MailClientTest {
     @Test
     public void testBlockingAPI() {
         MailClient client = MailClient.createShared(vertx, new MailConfig()
-                .setPort(container.getMappedPort(25))
-                .setHostname(container.getContainerIpAddress()));
+                .setPort(container.getMappedPort(1025))
+                .setHostname(container.getHost()));
         assertThat(client, is(notNullValue()));
         client.sendMailAndAwait(new MailMessage().setText("hello mutiny")
                 .setSubject("test email")

--- a/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
@@ -22,8 +22,7 @@
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
             <artifactId>${gen-source-artifactId}</artifactId>
-            <!-- This is because of the close method that changed its signature in 4.3.3 -->
-            <version>${vertx.version}.1</version>
+            <version>${vertx.version}</version>
         </dependency>
 
         <!-- Vert.x Mutiny Core -->


### PR DESCRIPTION
This PR cherry-picks are a few commits made against the main branch:

- update to Vert.x 4.3.3
- removal of the specific Vert.x Web version
- update the compatibility report documentation