### PR TITLE
prepare release 2.26.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 2.25.0
-  next-version: 2.26.0-SNAPSHOT
+  current-version: 2.26.0
+  next-version: 2.27.0-SNAPSHOT


### PR DESCRIPTION
- Bump vertx-core from 4.3.2 to 4.3.3
- Remove the specific version for Vert.x Web 4.2.3.1
- Update compatibility report documentation
- Update containers to work on ARM and AMD.
- Bump maven-javadoc-plugin from 3.4.0 to 3.4.1
- Prepare the 2.26.0 release
