### PR TITLE
Update Vertx to 3.4.5 and Mutiny to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,15 +46,15 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.3.4</vertx.version>
-        <mutiny.version>1.7.0</mutiny.version>
-        <jackson.version>2.13.4</jackson.version>
+        <vertx.version>4.3.5</vertx.version>
+        <mutiny.version>1.8.0</mutiny.version>
+        <jackson.version>2.14.0</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
 
         <rxjava3.version>3.1.5</rxjava3.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava1.version>1.3.8</rxjava1.version>
-        <reactor-core.version>3.4.21</reactor-core.version>
+        <reactor-core.version>3.5.0</reactor-core.version>
 
         <testcontainers.version>1.17.4</testcontainers.version>
 
@@ -340,7 +340,7 @@
                             <!-- Do not check for Vert.x, only focus on the client API -->
                             <checkDependencies>false</checkDependencies>
                             <generateSiteReport>false</generateSiteReport>
-                            <oldVersion>2.26.0</oldVersion>
+                            <oldVersion>2.27.0</oldVersion>
                             <newVersion>${project.version}</newVersion>
 
                             <analysisConfiguration>


### PR DESCRIPTION
Update various dependencies:

- update Vert.x to version 4.3.5
- update Mutiny to version 1.8.0
- update Jackson to version 2.14.0
- update Reactor Core to version 3.5.0
