### PR TITLE
Fix module name of the URI template module

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
@@ -78,7 +78,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.redis.client</Automatic-Module-Name>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.uri.template</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues/694