### PR TITLE
Mutiny 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
         <vertx.version>4.4.5</vertx.version>
-        <mutiny.version>2.4.0</mutiny.version>
+        <mutiny.version>2.5.0</mutiny.version>
         <jackson.version>2.15.2</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
 


### PR DESCRIPTION
This does not require a release as the upgrade from 2.4.0 to 2.5.0 is transparent.