### PR TITLE
Bump to Vert.x 4.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.5.0</vertx.version>
+        <vertx.version>4.5.1</vertx.version>
         <mutiny.version>2.5.3</mutiny.version>
         <jackson.version>2.16.0</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -55,6 +55,7 @@
         <module>vertx-mutiny-web-validation</module>
         <module>vertx-mutiny-web-openapi</module>
         <module>vertx-mutiny-web-api-service</module>
+        <module>vertx-mutiny-web-api-contract</module>
         <module>vertx-mutiny-web-templ-freemarker</module>
         <module>vertx-mutiny-web-templ-handlebars</module>
         <module>vertx-mutiny-web-templ-jade</module>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -58,6 +58,7 @@
         <module>vertx-mutiny-web-api-contract</module>
         <module>vertx-mutiny-web-templ-freemarker</module>
         <module>vertx-mutiny-web-templ-handlebars</module>
+        <module>vertx-mutiny-web-templ-httl</module>
         <module>vertx-mutiny-web-templ-jade</module>
         <module>vertx-mutiny-web-templ-mvel</module>
         <module>vertx-mutiny-web-templ-pebble</module>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -16,6 +16,7 @@
         <module>vertx-mutiny-runtime</module>
         <module>vertx-mutiny-core</module>
         <module>vertx-mutiny-junit5</module>
+        <module>vertx-mutiny-camel-bridge</module>
         <module>vertx-mutiny-mail-client</module>
         <module>vertx-mutiny-bridge-common</module>
         <module>vertx-mutiny-web-common</module>

--- a/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>vertx-mutiny-clients</artifactId>
+        <version>3.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-mutiny-vertx-camel-bridge</artifactId>
+    <name>SmallRye Mutiny - Vert.x Camel Bridge</name>
+
+    <properties>
+        <gen-source-groupId>io.vertx</gen-source-groupId>
+        <gen-source-artifactId>vertx-camel-bridge</gen-source-artifactId>
+        <gen.output>${project.build.directory}/sources/java</gen.output>
+    </properties>
+
+    <dependencies>
+        <!-- Generation source -->
+        <dependency>
+            <groupId>${gen-source-groupId}</groupId>
+            <artifactId>${gen-source-artifactId}</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
+        <!-- Vert.x mutiny Core -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>${gen-source-groupId}</includeGroupIds>
+                    <includeArtifactIds>${gen-source-artifactId}</includeArtifactIds>
+                    <classifier>sources</classifier>
+                    <includeTypes>jar</includeTypes>
+                </configuration>
+                <executions>
+                    <!-- Unpack java sources to target/java-sources -->
+                    <execution>
+                        <id>unpack-java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>io/vertx/**/*.java</includes>
+                            <excludes>**/impl/**/*.java</excludes>
+                            <outputDirectory>${gen.output}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.camel.bridge</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>5.0-jdk8</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                        </java.util.logging.SimpleFormatter.format>
+                        <mvel2.disable.jit>true</mvel2.disable.jit>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <!-- Run the annotation processor on java sources and generate the API -->
+                    <execution>
+                        <id>generate-api</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+                            <processors>
+                                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                            </processors>
+                            <optionMap>
+                                <codegen.generators>mutiny</codegen.generators>
+                            </optionMap>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>vertx-mutiny-clients</artifactId>
+        <version>3.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-mutiny-vertx-web-api-contract</artifactId>
+    <name>SmallRye Mutiny - Vert.x Web API Contract</name>
+
+    <properties>
+        <gen-source-groupId>io.vertx</gen-source-groupId>
+        <gen-source-artifactId>vertx-web-api-contract</gen-source-artifactId>
+        <gen.output>${project.build.directory}/sources/java</gen.output>
+    </properties>
+
+    <dependencies>
+        <!-- Generation source -->
+        <dependency>
+            <groupId>${gen-source-groupId}</groupId>
+            <artifactId>${gen-source-artifactId}</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
+        <!-- Dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>${gen-source-groupId}</includeGroupIds>
+                    <includeArtifactIds>${gen-source-artifactId}</includeArtifactIds>
+                    <classifier>sources</classifier>
+                    <includeTypes>jar</includeTypes>
+                </configuration>
+                <executions>
+                    <!-- Unpack java sources to target/java-sources -->
+                    <execution>
+                        <id>unpack-java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>io/vertx/**/*.java</includes>
+                            <excludes>**/impl/**/*.java</excludes>
+                            <outputDirectory>${gen.output}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.web.api.contract</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>5.0-jdk8</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                        </java.util.logging.SimpleFormatter.format>
+                        <mvel2.disable.jit>true</mvel2.disable.jit>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <!-- Run the annotation processor on java sources and generate the API -->
+                    <execution>
+                        <id>generate-api</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+                            <processors>
+                                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                            </processors>
+                            <optionMap>
+                                <codegen.generators>mutiny</codegen.generators>
+                            </optionMap>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>vertx-mutiny-clients</artifactId>
+        <version>3.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-mutiny-vertx-web-templ-httl</artifactId>
+    <name>SmallRye Mutiny - Vert.x Web - HTTL Template Engine</name>
+
+    <properties>
+        <gen-source-groupId>io.vertx</gen-source-groupId>
+        <gen-source-artifactId>vertx-web-templ-httl</gen-source-artifactId>
+        <gen.output>${project.build.directory}/sources/java</gen.output>
+    </properties>
+
+    <dependencies>
+        <!-- Generation source -->
+        <dependency>
+            <groupId>${gen-source-groupId}</groupId>
+            <artifactId>${gen-source-artifactId}</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
+        <!-- Thymeleaf depends on SLF4J -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>${gen-source-groupId}</includeGroupIds>
+                    <includeArtifactIds>${gen-source-artifactId}</includeArtifactIds>
+                    <classifier>sources</classifier>
+                    <includeTypes>jar</includeTypes>
+                </configuration>
+                <executions>
+                    <!-- Unpack java sources to target/java-sources -->
+                    <execution>
+                        <id>unpack-java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>io/vertx/**/*.java</includes>
+                            <excludes>**/impl/**/*.java</excludes>
+                            <outputDirectory>${gen.output}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.web.templ.httl</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>5.0-jdk8</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                        </java.util.logging.SimpleFormatter.format>
+                        <mvel2.disable.jit>true</mvel2.disable.jit>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <!-- Run the annotation processor on java sources and generate the API -->
+                    <execution>
+                        <id>generate-api</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+                            <processors>
+                                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                            </processors>
+                            <optionMap>
+                                <codegen.generators>mutiny</codegen.generators>
+                            </optionMap>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/ImportDeclarationCodeWriter.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/ImportDeclarationCodeWriter.java
@@ -4,7 +4,6 @@ import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.smallrye.common.annotation.CheckReturnValue;
@@ -24,7 +23,6 @@ public class ImportDeclarationCodeWriter implements CodeWriter {
         writer.println("import " + Collectors.class.getName() + ";");
         writer.println("import " + Multi.class.getName() + ";");
         writer.println("import " + Uni.class.getName() + ";");
-        writer.println("import " + Consumer.class.getName() + ";");
         writer.println("import " + TypeArg.class.getName() + ";");
         writer.println("import " + Fluent.class.getName() + ";");
         writer.println("import " + CheckReturnValue.class.getName() + ";");

--- a/vertx-mutiny-generator/src/tck/java/io/vertx/core/streams/Pump.java
+++ b/vertx-mutiny-generator/src/tck/java/io/vertx/core/streams/Pump.java
@@ -37,7 +37,9 @@ import io.vertx.core.streams.impl.PumpImpl;
  * Please see the documentation for more information.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @deprecated instead use {@link ReadStream#pipe()} or {@link ReadStream#pipeTo(WriteStream)}
  */
+@Deprecated
 @VertxGen
 public interface Pump {
 


### PR DESCRIPTION
- Bump to Vert.x 4.5.1
- Add generation for the Vert.x Camel Bridge
- Add generation for the Vert.x Web API Contract module
- Add generation for the Vert.x Web HTTL template engine


# API Change analysis

## Incompatible changes in vertx-mutiny-redis-client

| `method io.smallrye.mutiny.Uni<io.vertx.mutiny.redis.client.Response> io.vertx.mutiny.redis.client.RedisAPI::pfdebug(java.util.List<java.lang.String>)` a| 
* Source: BREAKING 
 * Binary: BREAKING | error | The number of parameters of the method have changed.

| `method io.vertx.mutiny.redis.client.Response io.vertx.mutiny.redis.client.RedisAPI::pfdebugAndAwait(java.util.List<java.lang.String>)` a| 
* Source: BREAKING 
 * Binary: BREAKING | error | The number of parameters of the method have changed.

| `method io.vertx.mutiny.redis.client.RedisAPI io.vertx.mutiny.redis.client.RedisAPI::pfdebugAndForget(java.util.List<java.lang.String>)` a| 
* Source: BREAKING 
 * Binary: BREAKING | error | The number of parameters of the method have changed.

|===
'''

## Incompatible changes in vertx-mutiny-core
[cols="1,1,1,1", options="header"]
|===
| Element | Classification | Criticality | Description

| `method io.smallrye.mutiny.Uni<java.lang.Void> io.vertx.mutiny.core.http.HttpClient::updateSSLOptions(io.vertx.core.net.SSLOptions)` a| 
* Source: BREAKING 
 * Binary: NON_BREAKING | error | The return type changed from 'io.smallrye.mutiny.Uni<java.lang.Void>' to 'io.smallrye.mutiny.Uni<java.lang.Boolean>'.

| `method java.lang.Void io.vertx.mutiny.core.http.HttpClient::updateSSLOptionsAndAwait(io.vertx.core.net.SSLOptions)` a| 
* Source: POTENTIALLY_BREAKING 
 * Binary: BREAKING | error | The return type changed from 'java.lang.Void' to  'java.lang.Boolean'.

| `method io.smallrye.mutiny.Uni<java.lang.Void> io.vertx.mutiny.core.http.HttpServer::updateSSLOptions(io.vertx.core.net.SSLOptions)` a| 
* Source: BREAKING 
 * Binary: NON_BREAKING | error | The return type changed from 'io.smallrye.mutiny.Uni<java.lang.Void>' to 'io.smallrye.mutiny.Uni<java.lang.Boolean>'.

| `method java.lang.Void io.vertx.mutiny.core.http.HttpServer::updateSSLOptionsAndAwait(io.vertx.core.net.SSLOptions)` a| 
* Source: POTENTIALLY_BREAKING 
 * Binary: BREAKING | error | The return type changed from 'java.lang.Void' to  'java.lang.Boolean'.

| `method io.vertx.mutiny.core.http.WebSocketBase io.vertx.mutiny.core.http.ServerWebSocket::writePingAndForget(io.vertx.mutiny.core.buffer.Buffer)` a| 
* Source: NON_BREAKING 
 * Binary: BREAKING | error | The return type changed covariantly from 'io.vertx.mutiny.core.http.WebSocketBase' to 'io.vertx.mutiny.core.http.ServerWebSocket'.

| `method io.vertx.mutiny.core.http.WebSocketBase io.vertx.mutiny.core.http.ServerWebSocket::writePongAndForget(io.vertx.mutiny.core.buffer.Buffer)` a| 
* Source: NON_BREAKING 
 * Binary: BREAKING | error | The return type changed covariantly from 'io.vertx.mutiny.core.http.WebSocketBase' to 'io.vertx.mutiny.core.http.ServerWebSocket'.

| `method io.vertx.mutiny.core.http.WebSocketBase io.vertx.mutiny.core.http.WebSocket::writePingAndForget(io.vertx.mutiny.core.buffer.Buffer)` a| 
* Source: NON_BREAKING 
 * Binary: BREAKING | error | The return type changed covariantly from 'io.vertx.mutiny.core.http.WebSocketBase' to 'io.vertx.mutiny.core.http.WebSocket'.

| `method io.vertx.mutiny.core.http.WebSocketBase io.vertx.mutiny.core.http.WebSocket::writePongAndForget(io.vertx.mutiny.core.buffer.Buffer)` a| 
* Source: NON_BREAKING 
 * Binary: BREAKING | error | The return type changed covariantly from 'io.vertx.mutiny.core.http.WebSocketBase' to 'io.vertx.mutiny.core.http.WebSocket'.

| `method io.smallrye.mutiny.Uni<java.lang.Void> io.vertx.mutiny.core.net.NetClient::updateSSLOptions(io.vertx.core.net.SSLOptions)` a| 
* Source: BREAKING 
 * Binary: NON_BREAKING | error | The return type changed from 'io.smallrye.mutiny.Uni<java.lang.Void>' to 'io.smallrye.mutiny.Uni<java.lang.Boolean>'.

| `method java.lang.Void io.vertx.mutiny.core.net.NetClient::updateSSLOptionsAndAwait(io.vertx.core.net.SSLOptions)` a| 
* Source: POTENTIALLY_BREAKING 
 * Binary: BREAKING | error | The return type changed from 'java.lang.Void' to  'java.lang.Boolean'.

| `method io.smallrye.mutiny.Uni<java.lang.Void> io.vertx.mutiny.core.net.NetServer::updateSSLOptions(io.vertx.core.net.SSLOptions)` a| 
* Source: BREAKING 
 * Binary: NON_BREAKING | error | The return type changed from 'io.smallrye.mutiny.Uni<java.lang.Void>' to 'io.smallrye.mutiny.Uni<java.lang.Boolean>'.

| `method java.lang.Void io.vertx.mutiny.core.net.NetServer::updateSSLOptionsAndAwait(io.vertx.core.net.SSLOptions)` a| 
* Source: POTENTIALLY_BREAKING 
 * Binary: BREAKING | error | The return type changed from 'java.lang.Void' to  'java.lang.Boolean'.

