### PR TITLE
Update Vert.x to version 4.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.5.3</vertx.version>
+        <vertx.version>4.5.4</vertx.version>
         <mutiny.version>2.5.6</mutiny.version>
         <jackson.version>2.16.1</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -357,7 +357,7 @@
                             <!-- Do not check for Vert.x, only focus on the client API -->
                             <checkDependencies>false</checkDependencies>
                             <generateSiteReport>false</generateSiteReport>
-                            <oldVersion>3.8.0</oldVersion>
+                            <oldVersion>3.9.0</oldVersion>
                             <newVersion>${project.version}</newVersion>
 
                             <analysisConfiguration>


### PR DESCRIPTION
Full release notes are there: https://github.com/vert-x3/wiki/wiki/4.5.4-Release-Notes.