### PR TITLE
Update Vert.x to version 4.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.5.4</vertx.version>
+        <vertx.version>4.5.5</vertx.version>
         <mutiny.version>2.5.6</mutiny.version>
         <jackson.version>2.17.0</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/MutinyMethodDescriptor.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/MutinyMethodDescriptor.java
@@ -2,10 +2,14 @@ package io.smallrye.mutiny.vertx.codegen.methods;
 
 import io.vertx.codegen.MethodInfo;
 
+import java.util.Set;
+
 /**
  * Just a structure describing a method.
  */
 public class MutinyMethodDescriptor {
+    private static final Set<String> NON_DEPRECATED_METHODS = Set.of("executeBlocking");
+
     public final boolean fluent;
     private final MutinyKind kind;
     private final MethodInfo method;
@@ -21,7 +25,7 @@ public class MutinyMethodDescriptor {
     }
 
     public MutinyMethodDescriptor(MethodInfo method, MethodInfo original, MutinyKind kind, boolean fluent,
-            boolean isPrivate) {
+                                  boolean isPrivate) {
         this.kind = kind;
         this.fluent = fluent;
         this.method = method;
@@ -62,6 +66,10 @@ public class MutinyMethodDescriptor {
     }
 
     public boolean isDeprecated() {
+        // Temporary workaround to avoid generating deprecated methods
+        if (NON_DEPRECATED_METHODS.contains(method.getName())) {
+            return false;
+        }
         return method.isDeprecated();
     }
 


### PR DESCRIPTION
Full release notes are there: https://github.com/vert-x3/wiki/wiki/4.5.5-Release-Notes.

Also work around the deprecation of some of the executeBlocking signatures.
