### PR TITLE
Prepare release 3.11.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 3.10.0
-  next-version: 3.11.0-SNAPSHOT
+  current-version: 3.11.0
+  next-version: 3.12.0-SNAPSHOT


### PR DESCRIPTION
The main change is the update to Vert.x 4.5.5 (https://github.com/vert-x3/wiki/wiki/4.5.5-Release-Notes)

Also work around the deprecation of some of the executeBlocking signatures.
