### PR TITLE
Bump Vert.x to 4.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <vertx.version>4.5.9</vertx.version>
+        <vertx.version>4.5.10</vertx.version>
         <mutiny.version>2.6.2</mutiny.version>
         <jackson.version>2.17.2</jackson.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -357,7 +357,7 @@
                             <!-- Do not check for Vert.x, only focus on the client API -->
                             <checkDependencies>false</checkDependencies>
                             <generateSiteReport>false</generateSiteReport>
-                            <oldVersion>3.9.0</oldVersion>
+                            <oldVersion>3.14.1</oldVersion>
                             <newVersion>${project.version}</newVersion>
 
                             <analysisConfiguration>


### PR DESCRIPTION
Potentially breaking change:


Element | Classification | Criticality | Description
-- | -- | -- | --
class io.vertx.mutiny.ext.auth.VertxContextPRNG | Source: POTENTIALLY_BREAKINGBinary: POTENTIALLY_BREAKING | error | Non-final class now inherits from 'io.vertx.mutiny.ext.auth.prng.VertxContextPRNG'.

Also, it is still not possible to update to Micrometer 1.13.x


