### PR TITLE
Revert "Bump micrometer.version from 1.12.5 to 1.13.6"

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
@@ -15,7 +15,7 @@
         <gen-source-groupId>io.vertx</gen-source-groupId>
         <gen-source-artifactId>vertx-micrometer-metrics</gen-source-artifactId>
         <gen.output>${project.build.directory}/sources/java</gen.output>
-        <micrometer.version>1.13.6</micrometer.version>
+        <micrometer.version>1.12.5</micrometer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This reverts commit d9ed655ec9fc38a9f928c8d6f879f014e760ba3c.