### PR TITLE
Release 3.15.2 RC2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 3.15.2-RC1
+  current-version: 3.15.2-RC2
   next-version: 3.15.2-SNAPSHOT

--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -73,6 +73,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -482,6 +483,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- **Set the deploy plugin version for the BOM module**
- **Release 3.15.2-RC2**
