### PR TITLE
Add bindings for Vert.x OpenAPI and Web OpenAPI Router

### DIFF
--- a/vertx-mutiny-clients-bom/pom.xml
+++ b/vertx-mutiny-clients-bom/pom.xml
@@ -220,6 +220,11 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-openapi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-mutiny-vertx-mqtt</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -291,6 +296,11 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-mutiny-vertx-web-openapi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-web-openapi-router</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -35,6 +35,7 @@
         <module>vertx-mutiny-mssql-client</module>
         <module>vertx-mutiny-mysql-client</module>
         <module>vertx-mutiny-oracle-client</module>
+        <module>vertx-mutiny-openapi</module>
         <module>vertx-mutiny-mqtt</module>
         <module>vertx-mutiny-auth-common</module>
         <module>vertx-mutiny-auth-jwt</module>
@@ -54,6 +55,7 @@
         <module>vertx-mutiny-json-schema</module>
         <module>vertx-mutiny-web-validation</module>
         <module>vertx-mutiny-web-openapi</module>
+        <module>vertx-mutiny-web-openapi-router</module>
         <module>vertx-mutiny-web-api-service</module>
         <module>vertx-mutiny-web-api-contract</module>
         <module>vertx-mutiny-web-templ-freemarker</module>

--- a/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
@@ -4,8 +4,8 @@
 
     <parent>
         <groupId>io.smallrye.reactive</groupId>
-        <artifactId>vertx-mutiny-openapi</artifactId>
-        <version>3.13.0-SNAPSHOT</version>
+        <artifactId>vertx-mutiny-clients</artifactId>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-mutiny-vertx-openapi</artifactId>

--- a/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>vertx-mutiny-openapi</artifactId>
+        <version>3.13.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-mutiny-vertx-openapi</artifactId>
+    <name>SmallRye Mutiny - Vert.x OpenAPI</name>
+
+    <properties>
+        <gen-source-groupId>io.vertx</gen-source-groupId>
+        <gen-source-artifactId>vertx-openapi</gen-source-artifactId>
+        <gen.output>${project.build.directory}/sources/java</gen.output>
+    </properties>
+
+    <dependencies>
+        <!-- Generation source -->
+        <dependency>
+            <groupId>${gen-source-groupId}</groupId>
+            <artifactId>${gen-source-artifactId}</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
+        <!-- Vert.x mutiny Core -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-json-schema</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>${gen-source-groupId}</includeGroupIds>
+                    <includeArtifactIds>${gen-source-artifactId}</includeArtifactIds>
+                    <classifier>sources</classifier>
+                    <includeTypes>jar</includeTypes>
+                </configuration>
+                <executions>
+                    <!-- Unpack java sources to target/java-sources -->
+                    <execution>
+                        <id>unpack-java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>io/vertx/**/*.java</includes>
+                            <excludes>**/impl/**/*.java</excludes>
+                            <outputDirectory>${gen.output}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.openapi</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>5.1-jdk8</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                        </java.util.logging.SimpleFormatter.format>
+                        <mvel2.disable.jit>true</mvel2.disable.jit>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <!-- Run the annotation processor on java sources and generate the API -->
+                    <execution>
+                        <id>generate-api</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+                            <processors>
+                                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                            </processors>
+                            <optionMap>
+                                <codegen.generators>mutiny</codegen.generators>
+                            </optionMap>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>vertx-mutiny-clients</artifactId>
+        <version>3.13.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-mutiny-vertx-web-openapi-router</artifactId>
+    <name>SmallRye Mutiny - Vert.x Web OpenAPI Router</name>
+
+    <properties>
+        <gen-source-groupId>io.vertx</gen-source-groupId>
+        <gen-source-artifactId>vertx-web-openapi-router</gen-source-artifactId>
+        <gen.output>${project.build.directory}/sources/java</gen.output>
+    </properties>
+
+    <dependencies>
+        <!-- Generation source -->
+        <dependency>
+            <groupId>${gen-source-groupId}</groupId>
+            <artifactId>${gen-source-artifactId}</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
+        <!-- Vert.x mutiny Core -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-json-schema</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-openapi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-auth-jwt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>${gen-source-groupId}</includeGroupIds>
+                    <includeArtifactIds>${gen-source-artifactId}</includeArtifactIds>
+                    <classifier>sources</classifier>
+                    <includeTypes>jar</includeTypes>
+                </configuration>
+                <executions>
+                    <!-- Unpack java sources to target/java-sources -->
+                    <execution>
+                        <id>unpack-java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>io/vertx/**/*.java</includes>
+                            <excludes>**/impl/**/*.java</excludes>
+                            <outputDirectory>${gen.output}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.web.openapi.router</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>5.1-jdk8</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                        </java.util.logging.SimpleFormatter.format>
+                        <mvel2.disable.jit>true</mvel2.disable.jit>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <!-- Run the annotation processor on java sources and generate the API -->
+                    <execution>
+                        <id>generate-api</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+                            <processors>
+                                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                            </processors>
+                            <optionMap>
+                                <codegen.generators>mutiny</codegen.generators>
+                            </optionMap>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>vertx-mutiny-clients</artifactId>
-        <version>3.13.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-mutiny-vertx-web-openapi-router</artifactId>

--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/MutinyGenerator.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/MutinyGenerator.java
@@ -322,7 +322,7 @@ public class MutinyGenerator extends Generator<ClassModel> {
                         "A method returning a 'Future' has been found - missing handler method for '" + method.getName()
                                 + "' declared in " + method.getOwnerTypes().stream().map(TypeInfo::getName)
                                 .collect(joining()));
-                uni.generateOther(method);
+                uni.generateOther(model, method);
                 await.generateOther(method);
                 forget.generateOther(model, method);
             } else {

--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/UniMethodGenerator.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/UniMethodGenerator.java
@@ -15,13 +15,12 @@ import io.vertx.codegen.type.ParameterizedTypeInfo;
 import io.vertx.codegen.type.TypeInfo;
 import io.vertx.core.Handler;
 
-import java.util.concurrent.Flow.Publisher;
-
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Flow.Publisher;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -61,11 +60,11 @@ public class UniMethodGenerator extends MutinyMethodGenerator {
         writer.println();
     }
 
-    public void generateOther(MethodInfo method) {
+    public void generateOther(ClassModel model, MethodInfo method) {
         MutinyMethodDescriptor uniMethod = computeMethodInfoOther(method);
         generateJavadoc(uniMethod);
         generateMethodDeclaration(uniMethod);
-        generateBodyOther(uniMethod);
+        generateBodyOther(model, uniMethod);
         writer.println();
     }
 
@@ -131,11 +130,12 @@ public class UniMethodGenerator extends MutinyMethodGenerator {
         return param.getType().isParameterized()  && param.getType().getRaw().getName().equals(Uni.class.getName());
     }
 
-    private void generateBodyOther(MutinyMethodDescriptor descriptor) {
+    private void generateBodyOther(ClassModel model, MutinyMethodDescriptor descriptor) {
         MethodInfo method = descriptor.getMethod();
 
         writer.println(" { ");
-        writer.print("    return " + UniHelper.class.getName() + ".toUni(delegate.");
+        String delegate = method.isStaticMethod() ? Helper.getNonGenericType(model.getIfaceFQCN()) : "delegate";
+        writer.print("    return " + UniHelper.class.getName() + ".toUni(" + delegate + ".");
         writer.print(method.getName());
         writer.print("(");
         List<ParamInfo> params = method.getParams();

--- a/vertx-mutiny-generator/src/tck/java/org/extra/StaticMethodWithFuture.java
+++ b/vertx-mutiny-generator/src/tck/java/org/extra/StaticMethodWithFuture.java
@@ -1,0 +1,23 @@
+package org.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+
+@VertxGen
+public interface StaticMethodWithFuture {
+
+    static Future<Void> doSomethingAsync() {
+        return Future.succeededFuture();
+    }
+
+    static Future<StaticMethodWithFuture> asyncCreate() {
+        return Future.succeededFuture(new StaticMethodWithFuture() {
+            @Override
+            public String sayHello() {
+                return "Hello static methods!";
+            }
+        });
+    }
+
+    String sayHello();
+}

--- a/vertx-mutiny-generator/src/test/java/tck/StaticMethodsTest.java
+++ b/vertx-mutiny-generator/src/test/java/tck/StaticMethodsTest.java
@@ -1,0 +1,25 @@
+package tck;
+
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.extra.mutiny.StaticMethodWithFuture;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StaticMethodsTest {
+
+    @Test
+    public void testInvokeStaticDoSomethingAsync() {
+        UniAssertSubscriber<Void> assertSubscriber = StaticMethodWithFuture.doSomethingAsync()
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        assertSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void testAsyncCreate() {
+        UniAssertSubscriber<StaticMethodWithFuture> assertSubscriber = StaticMethodWithFuture.asyncCreate()
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        StaticMethodWithFuture instance = assertSubscriber.assertCompleted().getItem();
+        assertEquals("Hello static methods!", instance.sayHello());
+    }
+}


### PR DESCRIPTION
Closes #920

Original PR https://github.com/smallrye/smallrye-mutiny-vertx-bindings/pull/926 by @pk-work was reverted because the generator does not support static method returning futures (see https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues/920#issuecomment-2158853882)

This PR adds support for such methods and brings back Vert.x OpenAPI and Web OpenAPI Router bindings.