### PR TITLE
Release 3.20.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 3.20.0
-  next-version: 3.20.1-SNAPSHOT
+  current-version: 3.20.1
+  next-version: 3.20.2-SNAPSHOT


### PR DESCRIPTION
Release version 3.20.1 with Mutiny 3.0.1 and Vert.x 4.5.22.