### PR TITLE
ClassCastException thrown by stream methods on Iterable types

### DIFF
--- a/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/SimpleMethodGenerator.java
+++ b/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/methods/SimpleMethodGenerator.java
@@ -148,11 +148,26 @@ public class SimpleMethodGenerator extends MutinyMethodGenerator {
     }
 
     public void generateOther(ClassModel model, MethodInfo method) {
+        if (isStreamMethod(model, method)) {
+            genStreamMethod(model, writer);
+            return;
+        }
         MutinyMethodDescriptor simpleMethod = computeMethodInfoOther(method);
         generateJavadoc(simpleMethod);
         generateMethodDeclaration(simpleMethod);
         generateBody(model, simpleMethod);
 
+        writer.println();
+    }
+
+    private boolean isStreamMethod(ClassModel model, MethodInfo method) {
+        return model.isIterable() && method.getName().equals("stream") && method.getParams().isEmpty() && method.getReturnType().getRaw().getName().equals("java.util.stream.Stream");
+    }
+
+    private void genStreamMethod(ClassModel model, PrintWriter writer) {
+        writer.printf("  public java.util.stream.Stream<%s> stream() {%n", CodeGenHelper.genTranslatedTypeName(model.getIterableArg()));
+        writer.println("    return java.util.stream.StreamSupport.stream(spliterator(), false);");
+        writer.println("  }");
         writer.println();
     }
 }

--- a/vertx-mutiny-generator/src/tck/java/org/extra/IterableWithStreamMethod.java
+++ b/vertx-mutiny-generator/src/tck/java/org/extra/IterableWithStreamMethod.java
@@ -1,0 +1,27 @@
+package org.extra;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
+@VertxGen
+public interface IterableWithStreamMethod extends Iterable<Foo> {
+    @GenIgnore
+    class Impl implements IterableWithStreamMethod {
+        @Override
+        public Iterator<Foo> iterator() {
+            return Arrays.<Foo>asList(new Foo.Impl(), new Foo.Impl()).iterator();
+        }
+    }
+
+    @GenIgnore(PERMITTED_TYPE)
+    default Stream<Foo> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+}

--- a/vertx-mutiny-generator/src/test/java/tck/StreamTest.java
+++ b/vertx-mutiny-generator/src/test/java/tck/StreamTest.java
@@ -1,0 +1,15 @@
+package tck;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamTest {
+
+    @Test
+    public void testStream() {
+        org.extra.IterableWithStreamMethod bareInstance = new org.extra.IterableWithStreamMethod.Impl();
+        org.extra.mutiny.IterableWithStreamMethod rxInstance = org.extra.mutiny.IterableWithStreamMethod.newInstance(bareInstance);
+        assertEquals(2, rxInstance.stream().count());
+    }
+}


### PR DESCRIPTION
See #1188

The exception is thrown if the iterable type argument is a Vert.x API type.

In this case, the type transformation is not applied (it's applied correctly for iterator methods).

The fix consists in generating a stream method that uses the iterator from the generated type, instead of invoking the delegate directly.