### PR TITLE
feat: add vertx-web

### DIFF
--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -22,7 +22,7 @@
                         <module>vertx-mutiny-mail-client</module>
                         <module>vertx-mutiny-bridge-common</module>
                         <module>vertx-mutiny-web-common</module>
-<!--                        <module>vertx-mutiny-web</module>-->
+                        <module>vertx-mutiny-web</module>
                         <module>vertx-mutiny-web-client</module>
                         <module>vertx-mutiny-mongo-client</module>
                         <module>vertx-mutiny-redis-client</module>

--- a/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
@@ -26,6 +26,12 @@
             <version>${vertx.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen-api</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+
         <!-- Vert.x Mutiny Core -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -38,11 +44,13 @@
             <artifactId>smallrye-mutiny-vertx-web-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-auth-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-bridge-common</artifactId>
@@ -55,49 +63,59 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-auth-htdigest</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-auth-webauthn4j</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-auth-otp</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-mutiny-vertx-health-check</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -132,7 +150,7 @@
                         <configuration>
                             <includes>io/vertx/**/*.java</includes>
                             <excludes>**/impl/**/*.java</excludes>
-                            <includeArtifactIds>vertx-core,vertx-web-common,vertx-auth-common,vertx-bridge-common,vertx-auth-jwt,vertx-auth-htdigest,vertx-auth-webauthn4j,vertx-auth-oauth2,vertx-auth-otp,vertx-uri-template,vertx-health-checks</includeArtifactIds>
+                            <includeArtifactIds>vertx-core,vertx-web-common,vertx-auth-common, vertx-bridge-common,vertx-auth-jwt,vertx-auth-htdigest, vertx-auth-webauthn4j,vertx-auth-oauth2,vertx-auth-otp,vertx-uri-template,vertx-health-checks</includeArtifactIds>
                             <outputDirectory>${project.basedir}/target/additional-sources/vertx-core</outputDirectory>
                         </configuration>
                     </execution>
@@ -175,6 +193,27 @@
                             <includePluginDependencies>true</includePluginDependencies>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>generate-test</id>
+                        <phase>
+                            generate-test-sources
+                        </phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.smallrye.mutiny.vertx.apigenerator.Main</mainClass>
+                            <arguments>
+                                <arg>--module-name=webtest</arg>
+                                <arg>--source=${project.basedir}/src/test/java/io/vertx/mutiny/web</arg>
+                                <arg>--output=${project.basedir}/target/generated-test-sources/codegen</arg>
+                                <arg>--additional-source=${project.basedir}/target/additional-sources/vertx-core</arg>
+                                <arg>--additional-source=${project.basedir}/target/sources</arg>
+                            </arguments>
+                            <includePluginDependencies>true</includePluginDependencies>
+                        </configuration>
+                    </execution>
                 </executions>
                 <dependencies>
                     <dependency>
@@ -198,6 +237,18 @@
                         <configuration>
                             <sources>
                                 <source>target/generated-sources/codegen</source>
+                            </sources>
+                        </configuration>
+                    </execution><!-- Run the annotation processor on java test sources -->
+                    <execution>
+                        <id>add-tests-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-test-sources/codegen</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web/src/test/java/io/vertx/mutiny/web/RouterTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-web/src/test/java/io/vertx/mutiny/web/RouterTest.java
@@ -1,22 +1,22 @@
 package io.vertx.mutiny.web;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.core.http.HttpClient;
+import io.vertx.mutiny.core.http.HttpClientAgent;
 import io.vertx.mutiny.core.http.HttpClientRequest;
 import io.vertx.mutiny.core.http.HttpServer;
 import io.vertx.mutiny.ext.web.Router;
@@ -32,9 +32,9 @@ public class RouterTest {
     private Vertx vertx;
     private Router router;
     private HttpServer server;
-    private HttpClient client;
+    private HttpClientAgent client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         vertx = Vertx.vertx();
         router = Router.router(vertx);
@@ -44,7 +44,7 @@ public class RouterTest {
         client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(server.actualPort()));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (client != null) {
             client.close().onFailure().recoverWithNull().await().indefinitely();

--- a/vertx-mutiny-clients/vertx-mutiny-web/src/test/java/io/vertx/mutiny/web/impl/TestRouteHandlerImpl.java
+++ b/vertx-mutiny-clients/vertx-mutiny-web/src/test/java/io/vertx/mutiny/web/impl/TestRouteHandlerImpl.java
@@ -23,4 +23,5 @@ public class TestRouteHandlerImpl implements TestRouteHandler, OrderListener {
     public void onOrder(int order) {
         called.set(true);
     }
+
 }

--- a/vertx-mutiny-code-generator/src/main/java/io/smallrye/mutiny/vertx/apigenerator/generator/ShimGenerator.java
+++ b/vertx-mutiny-code-generator/src/main/java/io/smallrye/mutiny/vertx/apigenerator/generator/ShimGenerator.java
@@ -57,6 +57,7 @@ public class ShimGenerator {
                 builder.addSuperinterface(JavaType.of(val).toTypeName());
             }
         }
+        builder.addSuperinterface(JavaType.of("io.smallrye.mutiny.vertx.MutinyDelegate").toTypeName());
 
         builder.addModifiers(Modifier.PUBLIC)
                 .addJavadoc(sanitize(shim.getJavaDoc().toText()))

--- a/vertx-mutiny-code-generator/src/test/java/io/smallrye/mutiny/vertx/apigenerator/generation/SomeTest.java
+++ b/vertx-mutiny-code-generator/src/test/java/io/smallrye/mutiny/vertx/apigenerator/generation/SomeTest.java
@@ -13,6 +13,7 @@ import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 
+import io.smallrye.mutiny.vertx.MutinyDelegate;
 import io.smallrye.mutiny.vertx.MutinyGen;
 import io.smallrye.mutiny.vertx.apigenerator.MutinyGenerator;
 import io.smallrye.mutiny.vertx.apigenerator.tests.Env;
@@ -49,7 +50,7 @@ public class SomeTest {
         assertThat(code.toString())
                 .contains("{@link me.escoffier.test.MyInterface")
                 .contains("@see me.escoffier.test.MyInterface");
-        assertThat(code.typeSpec().superinterfaces()).isEmpty();
+        assertThat(code.typeSpec().superinterfaces()).containsExactly(TypeName.get(MutinyDelegate.class));
         assertThat(code.typeSpec().superclass()).isEqualTo(TypeName.get(Object.class));
 
         env.compile();
@@ -85,7 +86,7 @@ public class SomeTest {
         assertThat(code.toString())
                 .contains("{@link me.escoffier.test.MyInterface")
                 .contains("@see me.escoffier.test.MyInterface");
-        assertThat(code.typeSpec().superinterfaces()).isEmpty();
+        assertThat(code.typeSpec().superinterfaces()).containsExactly(TypeName.get(MutinyDelegate.class));
         assertThat(code.typeSpec().superclass()).isEqualTo(TypeName.get(Object.class));
 
         env.compile();


### PR DESCRIPTION
- Had to add many additional sources for Router tests,
- Realized that the way we instantiate DelegatingHandler and DelegatingConsumer was wrong because of some checks performed to see if a handler implements OrderListener for instance.
- Added `implements MutinyDelegate` for all VertxGen classes as they all implement `getDelegate()` method.
