### PR TITLE
Automatic module for the Vert.x 4 codegen generator

### DIFF
--- a/vertx-mutiny-generator/pom.xml
+++ b/vertx-mutiny-generator/pom.xml
@@ -149,6 +149,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.codegen.generatorv4</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
Adds an automatic module name, see #1218

A separate modular name will be used for the Vert.x 5 in-progress branch.