### PR TITLE
feat: add an automatic module name to the generator

### DIFF
--- a/vertx-mutiny-code-generator/pom.xml
+++ b/vertx-mutiny-code-generator/pom.xml
@@ -71,6 +71,18 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.vertx.apigenerator</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Interestingly, providing a proper module-info is complicated due to the dependency on the vertx-core bindings module.