### PR TITLE
Fix vertx-mutiny-generator and vertx-codegen leaking to runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
         <assertj-core.version>3.27.7</assertj-core.version>
+        <log4j.version>2.25.3</log4j.version>
         <slf4j-api.version>2.0.17</slf4j-api.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
         <scram-client.version>3.2</scram-client.version>
@@ -88,6 +89,7 @@
 
         <jandex-maven-plugin.version>3.5.3</jandex-maven-plugin.version>
         <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
+        <maven-processor-plugin.version>5.1-jdk8</maven-processor-plugin.version>
         <bom-builder3.version>1.3.2</bom-builder3.version>
     </properties>
 

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -92,4 +92,46 @@
         <module>vertx-mutiny-http-proxy</module>
     </modules>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.bsc.maven</groupId>
+                    <artifactId>maven-processor-plugin</artifactId>
+                    <version>${maven-processor-plugin.version}</version>
+                    <configuration>
+                        <systemProperties>
+                            <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
+                            </java.util.logging.SimpleFormatter.format>
+                            <mvel2.disable.jit>true</mvel2.disable.jit>
+                        </systemProperties>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>vertx-mutiny-generator</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                        <!-- Log dependencies required by Vert.x -->
+                        <dependency>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-api</artifactId>
+                            <version>${log4j.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-core</artifactId>
+                            <version>${log4j.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                            <version>${slf4j-api.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>

--- a/vertx-mutiny-clients/vertx-mutiny-amqp-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-amqp-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-common/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -77,14 +82,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-htdigest/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-htdigest/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -82,14 +87,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-htpasswd/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-htpasswd/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -82,14 +87,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-jdbc/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-jdbc/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -87,14 +92,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-jwt/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-jwt/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -82,14 +87,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-ldap/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-ldap/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-mongo/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-mongo/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -87,14 +92,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-oauth2/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-oauth2/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -82,14 +87,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-otp/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-otp/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -82,14 +87,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-properties/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-properties/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-shiro/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-shiro/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -101,14 +106,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-webauthn/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-webauthn/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-bridge-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-bridge-common/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -79,14 +84,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -72,14 +77,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-cassandra-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-cassandra-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -103,14 +108,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-circuit-breaker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-circuit-breaker/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -89,14 +94,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-config/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-config/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-consul-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-consul-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -91,14 +96,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -21,6 +21,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
@@ -44,11 +49,6 @@
 
 
         <!-- Extra dependencies -->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>vertx-mutiny-generator</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -128,14 +128,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>
@@ -173,25 +165,6 @@
                         </configuration>
                     </execution>
                 </executions>
-
-                <!-- Log dependencies required by Vert.x -->
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-api</artifactId>
-                        <version>2.25.3</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-core</artifactId>
-                        <version>2.25.3</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                        <version>2.0.17</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -104,14 +109,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -102,14 +107,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-http-proxy/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-http-proxy/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-jdbc-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-jdbc-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -105,14 +110,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-json-schema/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-json-schema/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -84,14 +89,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-junit5/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-junit5/pom.xml
@@ -17,6 +17,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-kafka-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-kafka-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -121,14 +126,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-mail-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mail-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -86,14 +91,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
@@ -19,6 +19,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -116,14 +121,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-mongo-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mongo-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -91,14 +96,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-mqtt/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mqtt/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -90,14 +95,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-mssql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mssql-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -89,14 +94,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -105,14 +110,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -85,14 +90,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-oracle-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-oracle-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -105,14 +110,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -118,14 +123,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -97,14 +102,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-redis-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-redis-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -91,14 +96,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-consul/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-consul/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -93,14 +98,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-redis/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-redis/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -93,14 +98,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-zookeeper/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-consul/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-consul/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -93,14 +98,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker-links/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker-links/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-kubernetes/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-kubernetes/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-zookeeper/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-zookeeper/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -88,14 +93,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -113,14 +118,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-shell/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-shell/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -89,14 +94,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client-templates/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client-templates/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -105,14 +110,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -98,14 +103,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-stomp/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-stomp/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -95,14 +100,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-tcp-eventbus-bridge/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-tcp-eventbus-bridge/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -89,14 +94,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
@@ -19,6 +19,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -87,14 +92,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -80,14 +85,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-api-service/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-api-service/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -80,14 +85,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -132,14 +137,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-common/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -79,14 +84,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-cookie-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-cookie-session-store/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -81,14 +86,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-graphql/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-graphql/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-infinispan-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-infinispan-session-store/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -81,14 +86,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -126,14 +131,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -107,14 +112,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-proxy/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-proxy/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -89,14 +94,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-redis-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-redis-session-store/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -86,14 +91,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-freemarker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-freemarker/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-handlebars/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-handlebars/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -100,14 +105,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-jade/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-jade/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-mvel/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-mvel/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-pebble/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-pebble/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-pug/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-pug/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -94,14 +99,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-rocker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-rocker/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -100,14 +105,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-thymeleaf/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-thymeleaf/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -100,14 +105,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web-validation/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-validation/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -102,14 +107,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>

--- a/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
@@ -18,6 +18,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Generation source -->
         <dependency>
             <groupId>${gen-source-groupId}</groupId>
@@ -137,14 +142,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>5.1-jdk8</version>
-                <configuration>
-                    <systemProperties>
-                        <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n
-                        </java.util.logging.SimpleFormatter.format>
-                        <mvel2.disable.jit>true</mvel2.disable.jit>
-                    </systemProperties>
-                </configuration>
                 <executions>
                     <!-- Run the annotation processor on java sources and generate the API -->
                     <execution>


### PR DESCRIPTION
This is something that has apparently been fixed in main already but given Quarkus 3.x is far from being EOL, I think we should fix it in 3.x too.

I went with the approach of making the dependency optional and having it a dependency of the processor.
We need the dependency around because of the `@Fluent` marker annotation.

My question about this annotation: is it actually used by anything at runtime? It doesn't seem so but I wasn't able to fully rule it out, thus why I am asking.

Note that we also have a `@Fluent` in Quarkus:
TransactionalContextConnection in the Hibernate Reactive extension. This will require a fix.

CI seems to be happy about it so that's a good first step.