### PR TITLE
Fix codegen optional bump version and release 3.22.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Vert.x Bindings
 release:
-  current-version: 3.22.0
-  next-version: 3.22.1-SNAPSHOT
+  current-version: 3.22.1
+  next-version: 3.22.2-SNAPSHOT

--- a/vertx-mutiny-clients/vertx-mutiny-amqp-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-amqp-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-common/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-htdigest/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-htdigest/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-htpasswd/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-htpasswd/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-jdbc/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-jdbc/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-jwt/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-jwt/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-ldap/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-ldap/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-mongo/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-mongo/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-oauth2/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-oauth2/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-otp/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-otp/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-properties/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-properties/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-shiro/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-shiro/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-webauthn/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-webauthn/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-bridge-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-bridge-common/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-camel-bridge/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-cassandra-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-cassandra-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-circuit-breaker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-circuit-breaker/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-config/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-config/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-consul-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-consul-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-db2-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-health-checks/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-http-proxy/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-http-proxy/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-jdbc-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-jdbc-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-json-schema/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-json-schema/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-junit5/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-junit5/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-kafka-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-kafka-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-mail-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mail-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-micrometer-metrics/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-mongo-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mongo-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-mqtt/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mqtt/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-mssql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mssql-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-openapi/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-oracle-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-oracle-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-redis-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-redis-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-consul/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-consul/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-redis/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-redis/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-backend-zookeeper/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-consul/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-consul/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker-links/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker-links/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-docker/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-kubernetes/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-kubernetes/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-zookeeper/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery-bridge-zookeeper/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-service-discovery/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-service-discovery/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-shell/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-shell/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client-templates/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client-templates/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-stomp/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-stomp/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-tcp-eventbus-bridge/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-tcp-eventbus-bridge/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-uri-template/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-api-contract/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-api-service/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-api-service/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-client/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-common/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-common/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-cookie-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-cookie-session-store/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-graphql/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-graphql/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-infinispan-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-infinispan-session-store/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi-router/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-openapi/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-openapi/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-proxy/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-proxy/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-redis-session-store/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-redis-session-store/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-freemarker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-freemarker/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-handlebars/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-handlebars/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-httl/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-jade/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-jade/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-mvel/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-mvel/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-pebble/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-pebble/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-pug/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-pug/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-rocker/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-rocker/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-templ-thymeleaf/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-templ-thymeleaf/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web-validation/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web-validation/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>

--- a/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-web/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Generation source -->
         <dependency>


### PR DESCRIPTION
Remove `optional` property` on `vertx-codegen` dependencies that caused quarkus compilation to fail.
Bump version to release fix.